### PR TITLE
Allow JCF extensions inside WP themes.

### DIFF
--- a/just-custom-fields.php
+++ b/just-custom-fields.php
@@ -40,7 +40,7 @@ function pa($mixed, $stop = false) {
 }
 }
 
-add_action('plugins_loaded', 'jcf_init');
+add_action('after_setup_theme', 'jcf_init');
 function jcf_init(){
 	if( !is_admin() ) return;
 	


### PR DESCRIPTION
Link jcf_init() to action hook 'after_setup_theme' instead of 'plugins_loaded', so that any functions.php (parent and child) can be parsed beforehand. This allows JCF to be extended not only inside other plugins, but also inside regular themes.
