### PR TITLE
Netzgestaltung patch gutenberg related content

### DIFF
--- a/assets/just_custom_fields.js
+++ b/assets/just_custom_fields.js
@@ -92,14 +92,14 @@ function initFieldsetsEdit() {
   })
 
   // init delete button on change popup
-  jQuery('#jcf_ajax_content .jcf_edit_fieldset a.field-control-remove').live('click', function() {
+  jQuery('#jcf_ajax_content .jcf_edit_fieldset a.field-control-remove').on('click', function() {
     var f_id = jQuery(this).parents('form:first').find('input[name=fieldset_id]').val();
     jQuery('#jcf_fieldset_' + f_id + ' a.jcf_fieldset_delete').click();
     return false;
   });
 
   // save on edit form
-  jQuery('#jcform_edit_fieldset').live('submit', function( e ) {
+  jQuery('#jcform_edit_fieldset').on('submit', function( e ) {
     e.preventDefault();
     var f_id = jQuery(this).find('input[name=fieldset_id]').val();
     var data = {
@@ -139,7 +139,7 @@ function initFieldsetsEdit() {
   });
 
   // choose base for visibility rule (page template/taxonomy)
-  jQuery('#rule-based-on').live('change', function() {
+  jQuery('#rule-based-on').on('change', function() {
     var data = {
       'based_on': jQuery(this).val(),
       'action': 'jcf_get_rule_options',
@@ -151,7 +151,7 @@ function initFieldsetsEdit() {
   });
 
   // choose taxonomy terms for visibility rule
-  jQuery('#rule-taxonomy').live('change', function() {
+  jQuery('#rule-taxonomy').on('change', function() {
     var data = {
       'taxonomy': jQuery(this).val(),
       'action': 'jcf_get_taxonomy_terms',
@@ -165,7 +165,7 @@ function initFieldsetsEdit() {
   });
 
   //parse rule block for saving
-  jQuery('.save_rule_btn, .update_rule_btn').live('click', function(e) {
+  jQuery('.save_rule_btn, .update_rule_btn').on('click', function(e) {
     e.preventDefault();
 
     var f_id = jQuery(this).parents('form').find('input[name=fieldset_id]').val();
@@ -202,7 +202,7 @@ function initFieldsetsEdit() {
   });
 
   // add form for new visibility rule
-  jQuery('.add_rule_btn').live('click', function(e) {
+  jQuery('.add_rule_btn').on('click', function(e) {
     e.preventDefault();
 
     var data = {
@@ -216,7 +216,7 @@ function initFieldsetsEdit() {
   });
 
   // delete visibility rule
-  jQuery('a.remove-rule').live('click', function(e) {
+  jQuery('a.remove-rule').on('click', function(e) {
     e.preventDefault();
     var rule_id = jQuery(this).data('rule_id');
     var f_id = jQuery(this).parents('form').find('input[name=fieldset_id]').val();
@@ -233,7 +233,7 @@ function initFieldsetsEdit() {
   });
 
   // edit visibility rule
-  jQuery('a.edit-rule').live('click', function(e) {
+  jQuery('a.edit-rule').on('click', function(e) {
     e.preventDefault();
     var rule_id = jQuery(this).data('rule_id');
     var f_id = jQuery(this).parents('form').find('input[name=fieldset_id]').val();
@@ -253,7 +253,7 @@ function initFieldsetsEdit() {
   });
 
   // show/hide visibility options for fieldset
-  jQuery('a.visibility_toggle').live('click', function(e) {
+  jQuery('a.visibility_toggle').on('click', function(e) {
     e.preventDefault();
     jQuery('#visibility').toggle();
     jQuery(this).find('span').toggleClass('dashicons-arrow-down-alt2');
@@ -261,14 +261,14 @@ function initFieldsetsEdit() {
   });
 
   // cancel form for add or edit visibility rule
-  jQuery('.cancel_rule_btn').live('click', function(e) {
+  jQuery('.cancel_rule_btn').on('click', function(e) {
     e.preventDefault();
     jQuery(this).parents('fieldset#fieldset_visibility_rules').remove();
     jQuery('.add_rule_btn').show();
   });
 
   // adding new term for visility
-  jQuery('.termadd').live('click', function(e) {
+  jQuery('.termadd').on('click', function(e) {
     e.preventDefault();
     if ( !jQuery('#new-term').attr('data-term_id') && !jQuery('#new-term').attr('data-term_label') ) {
       var taxonomy = jQuery('.taxonomy-options #rule-taxonomy').val();
@@ -348,10 +348,93 @@ function initFieldsetFields() {
     return false;
   });
 
-  // init save button on edit form
-  jQuery('#jcform_edit_field').live('submit', function( e ) {
-    e.preventDefault();
+  // delete button
+  jQuery('#jcf_fieldsets tbody span.delete a').on('click', function() {
+    if ( confirm(jcf_textdomain.confirm_field_delete) ) {
+      var row = jQuery(this).parents('tr:first');
+      var f_id = jQuery(this).parents('tbody:first').attr('id').replace('the-list-', '');
+      var data = {
+        action: 'jcf_delete_field',
+        fieldset_id: f_id,
+        field_id: jQuery(this).attr('rel')
+      };
 
+      jcf_ajax(data, 'json', null, function( response ) {
+        row.next('td.collection_list:first').remove();
+        row.remove();
+        // close edit box if exists
+        jcf_hide_ajax_container();
+      });
+    }
+    return false;
+  })
+
+  // edit button
+  jQuery('#jcf_fieldsets tbody span.edit a, #jcf_fieldsets tbody strong > a').on('click', function() {
+    var f_id = jQuery(this).parents('tbody:first').attr('id').replace('the-list-', '');
+    var data = {
+      action: 'jcf_edit_field',
+      fieldset_id: f_id,
+      field_id: jQuery(this).attr('rel')
+    };
+
+    jcf_ajax(data, 'html', null, function( response ) {
+
+      jcf_show_ajax_container(response);
+
+    });
+
+    return false;
+  })
+
+  // delete button in edit form
+  jQuery('#jcform_edit_field a.field-control-remove').on('click', function( e ) {
+    var field_id = jQuery(this).parents('form:first').find('input[name=field_id]').val();
+    var row = jQuery('#field_row_' + field_id);
+    row.find('span.delete a').click();
+    return false;
+  });
+
+  // init sortable
+  jQuery('#jcf_fieldsets table.fieldset-fields-table > tbody').sortable({
+    handle: 'span.drag-handle',
+    opacity: 0.7,
+    placeholder: 'sortable_placeholder',
+    scroll: true,
+    start: function( event, ui ) {
+      ui.placeholder.html('<td colspan="5"><br>&nbsp;</td>');
+    },
+    stop: function( event, ui ) {
+      // ui.item - item in the list
+      var order = '';
+      var fieldset = jQuery(ui.item).parent();
+      var f_id = fieldset.attr('id').replace('the-list-', '');
+      fieldset.find('tr.field_row').each(function( i, tr ) {
+        if ( jQuery(tr).attr('id') )
+          order += jQuery(tr).attr('id').replace('field_row_', '') + ',';
+      });
+
+      var data = {
+        'action': 'jcf_fields_order',
+        'fieldset_id': f_id,
+        'fields_order': order
+      };
+      //pa(data);
+      jcf_ajax(data, 'json');
+    }
+  });
+
+}
+
+/**
+ * init form edit field after creation
+ */
+function jcf_init_edit_field(){
+
+  // init save button on edit form
+  jQuery('#jcform_edit_field').on('submit', function( e ) {
+    e.preventDefault();
+    
     // get query string from the form
     var query = jQuery('#jcform_edit_field').formSerialize();
     var data = 'action=jcf_save_field' + '&' + query;
@@ -429,83 +512,6 @@ function initFieldsetFields() {
 
     return false;
   });
-
-  // delete button
-  jQuery('#jcf_fieldsets tbody span.delete a').live('click', function() {
-    if ( confirm(jcf_textdomain.confirm_field_delete) ) {
-      var row = jQuery(this).parents('tr:first');
-      var f_id = jQuery(this).parents('tbody:first').attr('id').replace('the-list-', '');
-      var data = {
-        action: 'jcf_delete_field',
-        fieldset_id: f_id,
-        field_id: jQuery(this).attr('rel')
-      };
-
-      jcf_ajax(data, 'json', null, function( response ) {
-        row.next('td.collection_list:first').remove();
-        row.remove();
-        // close edit box if exists
-        jcf_hide_ajax_container();
-      });
-    }
-    return false;
-  })
-
-  // edit button
-  jQuery('#jcf_fieldsets tbody span.edit a, #jcf_fieldsets tbody strong > a').live('click', function() {
-    var f_id = jQuery(this).parents('tbody:first').attr('id').replace('the-list-', '');
-    var data = {
-      action: 'jcf_edit_field',
-      fieldset_id: f_id,
-      field_id: jQuery(this).attr('rel')
-    };
-
-    jcf_ajax(data, 'html', null, function( response ) {
-
-      jcf_show_ajax_container(response);
-
-    });
-
-    return false;
-  })
-
-  // delete button in edit form
-  jQuery('#jcform_edit_field a.field-control-remove').live('click', function( e ) {
-    var field_id = jQuery(this).parents('form:first').find('input[name=field_id]').val();
-    var row = jQuery('#field_row_' + field_id);
-    row.find('span.delete a').click();
-    return false;
-  });
-
-  // init sortable
-  jQuery('#jcf_fieldsets table.fieldset-fields-table > tbody').sortable({
-    handle: 'span.drag-handle',
-    opacity: 0.7,
-    placeholder: 'sortable_placeholder',
-    scroll: true,
-    start: function( event, ui ) {
-      ui.placeholder.html('<td colspan="5"><br>&nbsp;</td>');
-    },
-    stop: function( event, ui ) {
-      // ui.item - item in the list
-      var order = '';
-      var fieldset = jQuery(ui.item).parent();
-      var f_id = fieldset.attr('id').replace('the-list-', '');
-      fieldset.find('tr.field_row').each(function( i, tr ) {
-        if ( jQuery(tr).attr('id') )
-          order += jQuery(tr).attr('id').replace('field_row_', '') + ',';
-      });
-
-      var data = {
-        'action': 'jcf_fields_order',
-        'fieldset_id': f_id,
-        'fields_order': order
-      };
-      //pa(data);
-      jcf_ajax(data, 'json');
-    }
-  });
-
 }
 
 /**
@@ -556,7 +562,7 @@ function initExport() {
  */
 function initImportExportCheckboxes() {
   // checked fields
-  jQuery('#jcf_save_import_fields input[type="checkbox"], #jcf_export_fields input[type="checkbox"]').live('change', function() {
+  jQuery('#jcf_save_import_fields input[type="checkbox"], #jcf_export_fields input[type="checkbox"]').on('change', function() {
     var $this = jQuery(this);
     var data_checked = $this.is(':checked');
 
@@ -584,7 +590,7 @@ function initImportExportCheckboxes() {
  *	ajax functions below
  */
 function initAjaxBoxClose() {
-  jQuery('#jcf_ajax_content a.field-control-close').live('click', function() {
+  jQuery('#jcf_ajax_content a.field-control-close').on('click', function() {
     jcf_hide_ajax_container();
   });
 }
@@ -597,6 +603,7 @@ function jcf_hide_ajax_container() {
 function jcf_show_ajax_container( response ) {
   jQuery('#jcf_ajax_container').show();
   jQuery('#jcf_ajax_content').html(response);
+  jcf_init_edit_field();
 }
 
 function jcf_ajax( data, respType, loader, callback ) {

--- a/components/relatedcontent/related-content.js
+++ b/components/relatedcontent/related-content.js
@@ -8,12 +8,18 @@ if ( jQuery('body').hasClass('edit-tags-php') ) {
 }
 
 jQuery(document).ready(function() {
+  var timeout;
 
-  jcf_relatedcontent_init();
+  // Gutenberg loads metaboxes later
+  timeout = setTimeout(function(){
+    jcf_relatedcontent_init();
 
-  // add collection hook integration
-  jcf_add_action('collection_row_added', 'init_relatedcontent', jcf_relatedcontent_collection_init);
+    // add collection hook integration
+    jcf_add_action('collection_row_added', 'init_relatedcontent', jcf_relatedcontent_collection_init);
 
+    // reset timer
+    clearTimeout(timeout);
+  }, 50);
 });
 
 function jcf_relatedcontent_collection_init() {

--- a/components/relatedcontent/related-content.js
+++ b/components/relatedcontent/related-content.js
@@ -1,6 +1,6 @@
 var jcf_relatedcontent_max_index = 0;
 var jcf_relatedcontent_inited = false;
-var jcf_post_body_content_container = '#post-body';
+var jcf_post_body_content_container = '#post-body, #editor';
 if ( jQuery('body').hasClass('edit-tags-php') ) {
   jcf_post_body_content_container = '#addtag';
 } else if ( jQuery('body').hasClass('term-php') ) {


### PR DESCRIPTION
Hi there,

adding related content with the block editor is not possible.

i fixed that within this PR.

please consider to take it into an update.

the second changed file `just_custom_fields.js` is from PR #96 it wont show up if that one was merged.

br
tom